### PR TITLE
Fix total duration race condition that was breaking the slider and the video loading

### DIFF
--- a/lib/src/features/courses/presentation/course_player_page.dart
+++ b/lib/src/features/courses/presentation/course_player_page.dart
@@ -42,9 +42,6 @@ class CoursePlayerPage extends StatefulWidget {
 
 class _CoursePlayerPageState extends State<CoursePlayerPage>
     with WidgetsBindingObserver {
-  // Delay needed so Better Player is ready to accept seek operations.
-  static const Duration _videoRestoreDelay = Duration(milliseconds: 350);
-
   final ProgressStorage _progressStorage = ProgressStorage();
   final FavoritesStorage _favoritesStorage = FavoritesStorage();
 
@@ -54,6 +51,8 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
   bool _isCompleted = false;
   bool _isCurrentFavorite = false;
   String? _initializationError;
+  bool _isVideoReady = false;
+  bool _videoInitFailed = false;
   int _savedMediaPositionMs = 0;
   int _resourcePreparationRequestId = 0;
   String? _activeMediaResourceKey;
@@ -619,6 +618,15 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
       return _buildEmptyViewer('No se pudo cargar el video.');
     }
 
+    if (!_isVideoReady) {
+      if (_videoInitFailed) {
+        return _buildEmptyViewer(
+          'No se pudo inicializar el video. Toca el recurso de nuevo para reintentar.',
+        );
+      }
+      return _buildLoadingViewer();
+    }
+
     return SizedBox(
       height: 240,
       child: Container(
@@ -702,6 +710,22 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
               style: Theme.of(context).textTheme.bodyMedium,
             ),
           ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLoadingViewer() {
+    return SizedBox(
+      height: 240,
+      child: Container(
+        margin: const EdgeInsets.symmetric(horizontal: 14),
+        decoration: BoxDecoration(
+          color: Colors.black,
+          borderRadius: BorderRadius.circular(14),
+        ),
+        child: const Center(
+          child: CircularProgressIndicator(color: Color(0xFFFFD700)),
         ),
       ),
     );
@@ -991,16 +1015,20 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
     }
 
     if (resource.isVideo) {
-      final videoController = _buildVideoController(
-        resource.url,
-        requestId: requestId,
-      );
+      final videoController = _buildVideoController(resource.url);
       if (!mounted || requestId != _resourcePreparationRequestId) {
         videoController.dispose();
         return;
       }
       _videoController = videoController;
       _activeMediaResourceKey = _currentMediaResourceKey;
+      _isVideoReady = false;
+      _videoInitFailed = false;
+      _startVideoInitializationCheck(
+        videoController,
+        requestId,
+        restorePositionMs: _savedMediaPositionMs,
+      );
       return;
     }
     if (resource.isAudio) {
@@ -1037,11 +1065,7 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
     _setupDocument(resource.url);
   }
 
-  BetterPlayerController _buildVideoController(
-    String url, {
-    required int requestId,
-  }) {
-    final restorePositionMs = _savedMediaPositionMs;
+  BetterPlayerController _buildVideoController(String url) {
     final dataSource = BetterPlayerDataSource(
       BetterPlayerDataSourceType.network,
       url,
@@ -1074,23 +1098,63 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
           loadingColor: AppTheme.gold,
           progressBarBackgroundColor: Color(0x44FFFFFF),
           progressBarPlayedColor: AppTheme.gold,
+          playerTheme: BetterPlayerTheme.material,
         ),
       ),
       betterPlayerDataSource: dataSource,
     );
 
-    if (restorePositionMs > 0) {
-      // Better Player may ignore immediate seeks until the first frame is ready.
-      Future<void>.delayed(_videoRestoreDelay, () {
-        if (!mounted ||
-            requestId != _resourcePreparationRequestId ||
-            _videoController != videoController) {
-          return;
-        }
-        videoController.seekTo(Duration(milliseconds: restorePositionMs));
-      });
-    }
     return videoController;
+  }
+
+  void _startVideoInitializationCheck(
+    BetterPlayerController controller,
+    int requestId, {
+    required int restorePositionMs,
+  }) {
+    int attempts = 0;
+    const maxAttempts = 120;
+    Timer.periodic(const Duration(milliseconds: 100), (timer) {
+      if (!mounted ||
+          requestId != _resourcePreparationRequestId ||
+          _videoController != controller) {
+        timer.cancel();
+        return;
+      }
+
+      final videoPlayerController = controller.videoPlayerController;
+      final value = videoPlayerController?.value;
+      final duration = value?.duration;
+      final hasDuration = duration != null && duration > Duration.zero;
+      final isReady = value != null && value.initialized && hasDuration;
+
+      if (isReady) {
+        timer.cancel();
+        if (restorePositionMs > 0) {
+          final durationMs = duration.inMilliseconds;
+          final clampedPositionMs = restorePositionMs.clamp(0, durationMs);
+          try {
+            controller.seekTo(Duration(milliseconds: clampedPositionMs));
+          } catch (_) {}
+        }
+        if (mounted && requestId == _resourcePreparationRequestId) {
+          setState(() {
+            _isVideoReady = true;
+            _videoInitFailed = false;
+          });
+        }
+        return;
+      }
+      attempts++;
+      if (attempts >= maxAttempts) {
+        timer.cancel();
+        if (mounted && requestId == _resourcePreparationRequestId) {
+          setState(() {
+            _videoInitFailed = true;
+          });
+        }
+      }
+    });
   }
 
   void _setupDocument(String url) {

--- a/lib/src/features/courses/presentation/course_player_page.dart
+++ b/lib/src/features/courses/presentation/course_player_page.dart
@@ -1112,12 +1112,18 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
     int requestId, {
     required int restorePositionMs,
   }) {
+    _debugVideoInitLog(
+      'start requestId=$requestId resource=$_currentMediaResourceKey restoreMs=$restorePositionMs',
+    );
     int attempts = 0;
     const maxAttempts = 120;
     Timer.periodic(const Duration(milliseconds: 100), (timer) {
       if (!mounted ||
           requestId != _resourcePreparationRequestId ||
           _videoController != controller) {
+        _debugVideoInitLog(
+          'cancel requestId=$requestId mounted=$mounted activeRequest=$_resourcePreparationRequestId controllerChanged=${_videoController != controller}',
+        );
         timer.cancel();
         return;
       }
@@ -1128,13 +1134,27 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
       final hasDuration = duration != null && duration > Duration.zero;
       final isReady = value != null && value.initialized && hasDuration;
 
+      // Debug-only telemetry to understand readiness timing differences across
+      // devices/simulators without flooding release logs.
+      if (attempts == 0 || attempts % 10 == 0) {
+        _debugVideoInitLog(
+          'poll requestId=$requestId attempt=$attempts initialized=${value?.initialized} duration=$duration',
+        );
+      }
+
       if (isReady) {
         timer.cancel();
+        _debugVideoInitLog(
+          'ready requestId=$requestId attempt=$attempts duration=$duration',
+        );
         if (restorePositionMs > 0) {
           final durationMs = duration.inMilliseconds;
           final clampedPositionMs = restorePositionMs.clamp(0, durationMs);
           try {
             controller.seekTo(Duration(milliseconds: clampedPositionMs));
+            _debugVideoInitLog(
+              'seek requestId=$requestId targetMs=$clampedPositionMs durationMs=$durationMs',
+            );
           } catch (_) {}
         }
         if (mounted && requestId == _resourcePreparationRequestId) {
@@ -1148,6 +1168,9 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
       attempts++;
       if (attempts >= maxAttempts) {
         timer.cancel();
+        _debugVideoInitLog(
+          'timeout requestId=$requestId attempts=$attempts initialized=${value?.initialized} duration=$duration',
+        );
         if (mounted && requestId == _resourcePreparationRequestId) {
           setState(() {
             _videoInitFailed = true;
@@ -1155,6 +1178,15 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
         }
       }
     });
+  }
+
+  // Purpose: provide deep diagnostics for video initialization races in debug
+  // builds only. Using assert keeps logs out of release/profile builds.
+  void _debugVideoInitLog(String message) {
+    assert(() {
+      debugPrint('[CoursePlayer:VideoInit] $message');
+      return true;
+    }());
   }
 
   void _setupDocument(String url) {

--- a/lib/src/features/courses/presentation/course_player_page.dart
+++ b/lib/src/features/courses/presentation/course_player_page.dart
@@ -725,7 +725,7 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
           borderRadius: BorderRadius.circular(14),
         ),
         child: const Center(
-          child: CircularProgressIndicator(color: Color(0xFFFFD700)),
+          child: CircularProgressIndicator(color: AppTheme.gold),
         ),
       ),
     );


### PR DESCRIPTION


GPT context:

Great — glad it worked. Here’s exactly what I spotted and why this fix addressed it.
- Your symptom was very diagnostic: first load showed slider max as 1:00:00, second load was correct. That usually means the player UI rendered before real duration metadata was ready.
- In our code, _buildVideoViewer() rendered BetterPlayer when _isVideoReady == true.
- In _startVideoInitializationCheck(), we were setting _isVideoReady = true too early in some paths (especially timeout/fallback behavior), so the widget could render with incomplete metadata.
- I also verified the underlying plugin model (better_player_plus video value): duration is nullable and “initialized” state is tied to duration availability. So we needed to gate on actual duration, not just a high-level ready signal.
What I changed in lib/src/features/courses/presentation/course_player_page.dart:
- Added stricter readiness check against the underlying value:
  - value.initialized
  - duration != null
  - duration > Duration.zero
- Moved seek to happen only after that strict ready condition.
- Clamped seek position to known duration before seeking.
- Changed timeout behavior:
  - before: it could effectively allow render even without valid duration
  - now: it marks failure (_videoInitFailed = true) and shows a retry message instead of rendering a broken slider
- Kept render gating so BetterPlayer only appears when metadata is truly usable.
Why this fixed your case:
- The slider’s max/duration is now only read after valid duration exists.
- So first paint of controls already has real metadata, not placeholder/unstable values.
- That removes the “first load wrong, second load correct” behavior.
If you want, I can also add lightweight debug logs around readiness and duration (only in debug mode) so we can prove timing on different devices.
▣  Build · GPT-5.3-Codex · 17.8s
ok, go into more detail. Use code examples. I want to understand as fully, in depth as you would be talking to another engineer
→ Read Code/FCD/lib/src/features/courses/presentation/course_player_page.dart [offset=610, limit=190]
→ Read Code/FCD/lib/src/features/courses/presentation/course_player_page.dart [offset=1000, limit=220]
Perfect question. Here’s the engineering-level breakdown.
What tipped me off
Your behavior pattern was:
- First open of a video resource: slider max/time is wrong (e.g., looks like 1h)
- Re-open same resource: slider/time becomes correct
That is almost always a metadata readiness race, not a pure rendering bug:
- player widget renders
- control bar asks for duration
- duration is still placeholder/unstable on first paint
- later, AVPlayer metadata catches up
The second open works because duration is already known/cached by then.
Where the race was in our code
Before hardening, we effectively had this lifecycle:
_videoController = videoController;
_isVideoReady = false;
_startVideoInitializationCheck(...);
And in the checker we were “ready enough” too early in previous iterations (or timing out into rendering state), which still allowed controls to appear before duration was truly valid.
The key mistake in these systems is treating “controller exists” or “initialized event fired” as equivalent to “controls can safely read duration”. They are not always equivalent on iOS.
What I changed
1) Render gating by explicit ready flag
In _buildVideoViewer():
if (!_isVideoReady) {
  if (_videoInitFailed) {
    return _buildEmptyViewer('No se pudo inicializar...');
  }
  return _buildLoadingViewer();
}
return BetterPlayer(controller: controller);
So controls never mount until _isVideoReady == true.
2) Strict readiness condition (not just “initialized”)
In _startVideoInitializationCheck() we now poll and require:
final value = controller.videoPlayerController?.value;
final duration = value?.duration;
final hasDuration = duration != null && duration > Duration.zero;
final isReady = value != null && value.initialized && hasDuration;
This is the critical part:
- value.initialized alone can still be insufficient in these timing windows
- we also require real non-zero duration
Only then we flip UI ready:
setState(() {
  _isVideoReady = true;
  _videoInitFailed = false;
});
3) Seek only after strict ready + clamped
We moved seek behind readiness and clamp:
if (restorePositionMs > 0) {
  final durationMs = duration.inMilliseconds;
  final clampedPositionMs = restorePositionMs.clamp(0, durationMs);
  controller.seekTo(Duration(milliseconds: clampedPositionMs));
}
This avoids:
- “not initialized yet” seek errors
- seeking beyond duration
4) Explicit failure mode (instead of broken slider)
If never ready after polling window (~12s):
if (attempts >= maxAttempts) {
  setState(() {
    _videoInitFailed = true;
  });
}
So user gets deterministic “retry” state instead of malformed controls.
---
Why this works conceptually
Think of the player state machine as:
- ControllerCreated
- NativePipelineBooting
- MetadataAvailable(duration)
- SafeToRenderControls
Old behavior rendered near ControllerCreated/Booting.
New behavior renders only at MetadataAvailable.
That removes first-paint garbage in progress UI.
---
Why NaN disappeared
NaN in controls usually comes from math like:
- position / duration
- width calculations from invalid progress
- duration == 0 or null path not fully guarded in plugin internals
By not mounting controls until duration is valid, we avoid feeding those bad inputs into BetterPlayer controls.
---
Important nuance
Even with this hardening, third-party controls can still have internal edge bugs. But this pattern is the safest app-side contract:
- don’t trust plugin event timing blindly
- gate render by strict media invariants (initialized + duration>0)
- only seek after those invariants hold
---
If you want, next step I can add temporary debug logs around readiness transitions (attempt count, duration values, initialized flag) so you can see this timeline per device/simulator and keep it as a regression aid.
▣  Build · GPT-5.3-Codex · 25.3s