### PR TITLE
Improve download UX across app

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -1,4 +1,5 @@
 import 'package:fcd_app/src/core/theme/app_theme.dart';
+import 'package:fcd_app/src/core/navigation/route_observer.dart';
 import 'package:fcd_app/src/features/auth/presentation/login_page.dart';
 import 'package:fcd_app/src/features/home/presentation/home_shell.dart';
 import 'package:fcd_app/src/features/splash/presentation/splash_page.dart';
@@ -15,6 +16,7 @@ class FcdApp extends StatelessWidget {
       title: 'FCD',
       debugShowCheckedModeBanner: false,
       theme: AppTheme.light(),
+      navigatorObservers: <NavigatorObserver>[routeObserver],
       home: const _BootstrapGate(),
     );
   }

--- a/lib/src/core/navigation/route_observer.dart
+++ b/lib/src/core/navigation/route_observer.dart
@@ -1,0 +1,4 @@
+import 'package:flutter/material.dart';
+
+final RouteObserver<ModalRoute<void>> routeObserver =
+    RouteObserver<ModalRoute<void>>();

--- a/lib/src/features/courses/presentation/course_player_page.dart
+++ b/lib/src/features/courses/presentation/course_player_page.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:audio_service/audio_service.dart';
 import 'package:better_player_plus/better_player_plus.dart';
 import 'package:fcd_app/src/core/config/api_config.dart';
+import 'package:fcd_app/src/core/navigation/route_observer.dart';
 import 'package:fcd_app/src/core/storage/favorites_storage.dart';
 import 'package:fcd_app/src/core/storage/progress_storage.dart';
 import 'package:fcd_app/src/core/theme/app_theme.dart';
@@ -10,6 +11,8 @@ import 'package:fcd_app/src/core/widgets/audio_player_widget.dart';
 import 'package:fcd_app/src/features/courses/data/models/course.dart';
 import 'package:fcd_app/src/features/courses/data/models/course_lesson.dart';
 import 'package:fcd_app/src/features/courses/data/models/lesson_resource.dart';
+import 'package:fcd_app/src/features/downloads/data/repositories/download_repository.dart';
+import 'package:fcd_app/src/features/downloads/presentation/download_progress_banner.dart';
 import 'package:fcd_app/src/features/downloads/presentation/download_task_controller.dart';
 import 'package:fcd_app/src/state/session_controller.dart';
 import 'package:flutter/material.dart';
@@ -44,9 +47,10 @@ class CoursePlayerPage extends StatefulWidget {
 }
 
 class _CoursePlayerPageState extends State<CoursePlayerPage>
-    with WidgetsBindingObserver {
+    with WidgetsBindingObserver, RouteAware {
   final ProgressStorage _progressStorage = ProgressStorage();
   final FavoritesStorage _favoritesStorage = FavoritesStorage();
+  late final DownloadRepository _downloadRepository;
 
   int _lessonIndex = 0;
   int _resourceIndex = 0;
@@ -62,6 +66,8 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
   int _resourcePreparationRequestId = 0;
   String? _activeMediaResourceKey;
   bool _showSessionExpiredBanner = false;
+  bool _downloadsExpanded = false;
+  Set<String> _downloadedResourceKeys = <String>{};
 
   BetterPlayerController? _videoController;
   AudioPlayer? _audioPlayer;
@@ -76,7 +82,11 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    _downloadRepository = DownloadRepository(
+      apiClient: context.read<SessionController>().apiClient,
+    );
     _initializeProgress();
+    _refreshDownloadedResources();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _checkSessionStatus();
     });
@@ -85,15 +95,21 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    final route = ModalRoute.of(context);
+    if (route != null) {
+      routeObserver.subscribe(this, route);
+    }
     final session = context.read<SessionController>();
     if (_cachedSession == null) {
       session.addListener(_onSessionChanged);
       _cachedSession = session;
     }
+    _refreshDownloadedResources();
   }
 
   @override
   void dispose() {
+    routeObserver.unsubscribe(this);
     WidgetsBinding.instance.removeObserver(this);
     _saveProgressOnDispose();
     _videoController?.dispose(forceDispose: true);
@@ -127,6 +143,14 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
     if (state == AppLifecycleState.paused) {
       _saveProgress();
     }
+    if (state == AppLifecycleState.resumed) {
+      _refreshDownloadedResources();
+    }
+  }
+
+  @override
+  void didPopNext() {
+    _refreshDownloadedResources();
   }
 
   Future<void> _initializeProgress() async {
@@ -279,28 +303,82 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
       );
     }
 
+    final content = Column(
+      children: <Widget>[
+        if (_showSessionExpiredBanner) _buildSessionExpiredBanner(context),
+        _buildTopBar(context),
+        _buildProgressBanner(context),
+        Expanded(
+          child: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                _buildViewer(context),
+                _buildBottomPanel(context),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+
     return Scaffold(
       drawer: _buildLessonsDrawer(context),
       body: SafeArea(
-        child: Column(
+        child: Stack(
           children: <Widget>[
-            if (_showSessionExpiredBanner) _buildSessionExpiredBanner(context),
-            _buildTopBar(context),
-            _buildProgressBanner(context),
-            Expanded(
-              child: SingleChildScrollView(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: <Widget>[
-                    _buildViewer(context),
-                    _buildBottomPanel(context),
-                  ],
+            NotificationListener<ScrollNotification>(
+              onNotification: (notification) {
+                if (_downloadsExpanded &&
+                    notification is ScrollStartNotification) {
+                  _collapseDownloadsBanner();
+                }
+                return false;
+              },
+              child: content,
+            ),
+            if (_downloadsExpanded)
+              Positioned.fill(
+                child: GestureDetector(
+                  onTap: _collapseDownloadsBanner,
+                  behavior: HitTestBehavior.translucent,
                 ),
               ),
+            Positioned(
+              top: 0,
+              left: 0,
+              right: 0,
+              child: _buildDownloadsBanner(context),
             ),
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildDownloadsBanner(BuildContext context) {
+    final downloadController = context.watch<DownloadTaskController>();
+    final hasDownloads = downloadController.hasActiveDownloads;
+    final isDownloadsExpanded = _downloadsExpanded && hasDownloads;
+
+    if (_downloadsExpanded && !hasDownloads) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          setState(() {
+            _downloadsExpanded = false;
+          });
+        }
+      });
+    }
+
+    if (!hasDownloads) {
+      return const SizedBox.shrink();
+    }
+
+    return DownloadProgressBanner(
+      controller: downloadController,
+      expanded: isDownloadsExpanded,
+      onToggle: _toggleDownloadsBanner,
     );
   }
 
@@ -540,6 +618,10 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
 
   Widget _buildBottomPanel(BuildContext context) {
     final downloadController = context.watch<DownloadTaskController>();
+    final resource = currentResource;
+    final isDownloading =
+        resource != null && downloadController.isDownloadingResource(resource);
+    final isDownloaded = resource != null && _isResourceDownloaded(resource);
 
     return Container(
       padding: const EdgeInsets.fromLTRB(14, 12, 14, 24),
@@ -587,23 +669,13 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
           ),
           const SizedBox(height: 12),
           ElevatedButton.icon(
-            onPressed: downloadController.isDownloading
-                ? null
-                : _downloadCurrentResource,
-            icon: downloadController.isDownloading
-                ? const SizedBox(
-                    width: 18,
-                    height: 18,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2,
-                      color: Colors.white,
-                    ),
-                  )
-                : const Icon(Icons.download_rounded),
+            onPressed:
+                isDownloading || isDownloaded ? null : _downloadCurrentResource,
+            icon: const Icon(Icons.download_rounded),
             label: Text(
-              downloadController.isDownloading
-                  ? 'Descargando ${(downloadController.progress * 100).toStringAsFixed(0)}%'
-                  : 'Descargar al teléfono',
+              isDownloading
+                  ? 'Descargando'
+                  : (isDownloaded ? 'Ya descargado' : 'Descargar al teléfono'),
             ),
           ),
           const SizedBox(height: 10),
@@ -623,6 +695,7 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
               child: _ResourceTile(
                 resource: item,
                 selected: index == _resourceIndex,
+                downloaded: _isResourceDownloaded(item),
                 onTap: () async {
                   setState(() {
                     _resourceIndex = index;
@@ -813,6 +886,13 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
       return;
     }
 
+    if (_isResourceDownloaded(resource)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Este recurso ya está descargado.')),
+      );
+      return;
+    }
+
     final downloadResource = resource.copyWithCourseMedia(
       courseBannerUrl: widget.course.bannerUrl,
       courseIconUrl: widget.course.iconUrl,
@@ -831,10 +911,11 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
     switch (result.status) {
       case DownloadTaskStatus.busy:
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Ya hay una descarga en progreso.')),
+          const SnackBar(content: Text('Este recurso ya se está descargando.')),
         );
         return;
       case DownloadTaskStatus.alreadyDownloaded:
+        await _refreshDownloadedResources();
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
             content: Text('Este recurso ya fue descargado previamente.'),
@@ -847,6 +928,7 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
         ).showSnackBar(const SnackBar(content: Text('No se pudo descargar.')));
         return;
       case DownloadTaskStatus.completed:
+        await _refreshDownloadedResources();
         final file = result.file;
         if (file == null) {
           ScaffoldMessenger.of(
@@ -881,6 +963,45 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
         return;
     }
   }
+
+  bool _isResourceDownloaded(LessonResource resource) {
+    return _downloadedResourceKeys.contains(_resourceKey(resource));
+  }
+
+  String _resourceKey(LessonResource resource) {
+    return '${resource.type.name}:${_normalizedResourceUrl(resource.url)}';
+  }
+
+  String _normalizedResourceUrl(String url) {
+    final uri = Uri.tryParse(url);
+    if (uri == null) {
+      return url;
+    }
+    if (uri.hasQuery || uri.fragment.isNotEmpty) {
+      return uri.replace(query: '', fragment: '').toString();
+    }
+    return uri.toString();
+  }
+
+  Future<void> _refreshDownloadedResources() async {
+    final cleanup = await _downloadRepository.removeMissingDownloads();
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      final keys = <String>{};
+      for (final file in cleanup.files) {
+        if (file.id.isNotEmpty) {
+          keys.add(file.id);
+        }
+        if (file.url.isNotEmpty) {
+          keys.add('${file.type}:${_normalizedResourceUrl(file.url)}');
+        }
+      }
+      _downloadedResourceKeys = keys;
+    });
+  }
+
 
   Future<void> _nextLesson() async {
     await _markCurrentAsSeen();
@@ -1054,14 +1175,12 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
     final previousAudioPlayer = _audioPlayer;
 
     _videoController = null;
-    _audioPlayer = null;
     _webViewController = null;
     _activeMediaResourceKey = null;
 
     previousVideoController?.dispose(forceDispose: true);
     if (previousAudioPlayer != null) {
       await previousAudioPlayer.stop();
-      await previousAudioPlayer.dispose();
     }
 
     if (!mounted || requestId != _resourcePreparationRequestId) {
@@ -1100,7 +1219,7 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
     if (resource.isAudio) {
       _isAudioLoading = true;
       setState(() {});
-      final audioPlayer = AudioPlayer();
+      final audioPlayer = _audioPlayer ??= AudioPlayer();
       final artworkUrl = widget.course.iconUrl.isNotEmpty
           ? widget.course.iconUrl
           : widget.course.bannerUrl;
@@ -1116,7 +1235,6 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
         ),
       );
       if (!mounted || requestId != _resourcePreparationRequestId) {
-        await audioPlayer.dispose();
         _isAudioLoading = false;
         return;
       }
@@ -1143,7 +1261,6 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
       }
       _activeMediaResourceKey = null;
       await audioPlayer.stop();
-      await audioPlayer.dispose();
       return;
     }
 
@@ -1305,6 +1422,21 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
     }());
   }
 
+  void _toggleDownloadsBanner() {
+    setState(() {
+      _downloadsExpanded = !_downloadsExpanded;
+    });
+  }
+
+  void _collapseDownloadsBanner() {
+    if (!_downloadsExpanded) {
+      return;
+    }
+    setState(() {
+      _downloadsExpanded = false;
+    });
+  }
+
   void _setupDocument(String url) {
     final viewerUrl =
         '${ApiConfig.googleViewerUrlPrefix}${Uri.encodeComponent(url)}';
@@ -1330,11 +1462,13 @@ class _ResourceTile extends StatelessWidget {
   const _ResourceTile({
     required this.resource,
     required this.selected,
+    required this.downloaded,
     required this.onTap,
   });
 
   final LessonResource resource;
   final bool selected;
+  final bool downloaded;
   final VoidCallback onTap;
 
   @override
@@ -1361,7 +1495,7 @@ class _ResourceTile extends StatelessWidget {
                   overflow: TextOverflow.ellipsis,
                 ),
               ),
-              if (selected)
+              if (downloaded)
                 const Icon(
                   Icons.check_circle_rounded,
                   color: AppTheme.deepBrown,

--- a/lib/src/features/courses/presentation/course_player_page.dart
+++ b/lib/src/features/courses/presentation/course_player_page.dart
@@ -95,7 +95,7 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final route = ModalRoute.of(context);
+    final route = ModalRoute.of(context) as ModalRoute<void>?;
     if (route != null) {
       routeObserver.subscribe(this, route);
     }

--- a/lib/src/features/courses/presentation/course_player_page.dart
+++ b/lib/src/features/courses/presentation/course_player_page.dart
@@ -922,6 +922,9 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
           ),
         );
         return;
+      case DownloadTaskStatus.canceled:
+        // User canceled, no error message needed
+        return;
       case DownloadTaskStatus.failed:
         ScaffoldMessenger.of(
           context,

--- a/lib/src/features/downloads/data/repositories/download_repository.dart
+++ b/lib/src/features/downloads/data/repositories/download_repository.dart
@@ -25,6 +25,24 @@ class DownloadRepository {
     return getApplicationSupportDirectory();
   }
 
+  /// Returns the file path where [resource] would be downloaded.
+  /// Creates the downloads directory if it doesn't exist.
+  Future<String> getDownloadFilePath(LessonResource resource) async {
+    final baseDir = await getBaseDirectory();
+    final folder = Directory('${baseDir.path}/downloads');
+    if (!await folder.exists()) {
+      await folder.create(recursive: true);
+    }
+
+    final extension = _extensionFromResource(resource);
+    final filename = _safeFileName(
+      resource.name,
+      resource.type.name,
+      extension,
+    );
+    return '${folder.path}/$filename';
+  }
+
   Future<File> downloadResource(
     LessonResource resource, {
     required ProgressCallback onProgress,
@@ -43,19 +61,8 @@ class DownloadRepository {
       return existingFile;
     }
 
-    final baseDir = await getBaseDirectory();
-    final folder = Directory('${baseDir.path}/downloads');
-    if (!await folder.exists()) {
-      await folder.create(recursive: true);
-    }
-
-    final extension = _extensionFromResource(resource);
-    final filename = _safeFileName(
-      resource.name,
-      resource.type.name,
-      extension,
-    );
-    final file = File('${folder.path}/$filename');
+    final filePath = await getDownloadFilePath(resource);
+    final file = File(filePath);
 
     await _apiClient.download(
       resource.url,
@@ -64,6 +71,7 @@ class DownloadRepository {
       cancelToken: cancelToken,
     );
 
+    final baseDir = await getBaseDirectory();
     final artworkUrl = resource.courseIconUrl.isNotEmpty
         ? resource.courseIconUrl
         : resource.courseBannerUrl;
@@ -258,6 +266,19 @@ class DownloadRepository {
     final parsed = await _readHistory();
     parsed.removeWhere((entry) => _isSameResourceEntry(entry, file));
     await _setHistory(parsed);
+  }
+
+  /// Deletes a partial download file at [filePath] if it exists.
+  /// Used to clean up orphaned files after download cancellation.
+  Future<void> deletePartialDownload(String filePath) async {
+    final file = File(filePath);
+    if (await file.exists()) {
+      try {
+        await file.delete();
+      } catch (_) {
+        // Ignore failures while cleaning up.
+      }
+    }
   }
 
   Future<void> _saveToHistory(DownloadedFile file) async {

--- a/lib/src/features/downloads/data/repositories/download_repository.dart
+++ b/lib/src/features/downloads/data/repositories/download_repository.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:dio/dio.dart';
@@ -13,6 +14,9 @@ class DownloadRepository {
   final ApiClient _apiClient;
 
   static const String _downloadHistoryKey = 'download_history_v1';
+  
+  // Serialize history updates to prevent lost-update races during concurrent downloads
+  Future<void>? _historyUpdateLock;
 
   Future<Directory> getBaseDirectory() async {
     if (Platform.isIOS) {
@@ -229,27 +233,52 @@ class DownloadRepository {
         // Ignore failures while cleaning up.
       }
     }
+    
+    // Only delete artwork if no other downloads reference it
     if (file.localArtworkPath.isNotEmpty) {
-      final artwork = File(file.localArtworkPath);
-      if (await artwork.exists()) {
-        try {
-          await artwork.delete();
-        } catch (_) {
-          // Ignore failures while cleaning up.
+      final parsed = await _readHistory();
+      final otherReferences = parsed.where(
+        (entry) => 
+          entry.localArtworkPath == file.localArtworkPath &&
+          !_isSameResourceEntry(entry, file),
+      ).isNotEmpty;
+      
+      if (!otherReferences) {
+        final artwork = File(file.localArtworkPath);
+        if (await artwork.exists()) {
+          try {
+            await artwork.delete();
+          } catch (_) {
+            // Ignore failures while cleaning up.
+          }
         }
       }
     }
+    
     final parsed = await _readHistory();
     parsed.removeWhere((entry) => _isSameResourceEntry(entry, file));
     await _setHistory(parsed);
   }
 
   Future<void> _saveToHistory(DownloadedFile file) async {
-    final parsed = await _readHistory();
-    parsed.removeWhere((entry) => _isSameResourceEntry(entry, file));
-    parsed.insert(0, file);
+    // Serialize history updates to prevent lost-update races
+    while (_historyUpdateLock != null) {
+      await _historyUpdateLock;
+    }
+    
+    final completer = Completer<void>();
+    _historyUpdateLock = completer.future;
+    
+    try {
+      final parsed = await _readHistory();
+      parsed.removeWhere((entry) => _isSameResourceEntry(entry, file));
+      parsed.insert(0, file);
 
-    await _setHistory(parsed);
+      await _setHistory(parsed);
+    } finally {
+      _historyUpdateLock = null;
+      completer.complete();
+    }
   }
 
   Future<void> _setHistory(List<DownloadedFile> files) async {

--- a/lib/src/features/downloads/data/repositories/download_repository.dart
+++ b/lib/src/features/downloads/data/repositories/download_repository.dart
@@ -220,6 +220,30 @@ class DownloadRepository {
     await prefs.remove(_downloadHistoryKey);
   }
 
+  Future<void> deleteDownload(DownloadedFile file) async {
+    final localFile = File(file.localPath);
+    if (await localFile.exists()) {
+      try {
+        await localFile.delete();
+      } catch (_) {
+        // Ignore failures while cleaning up.
+      }
+    }
+    if (file.localArtworkPath.isNotEmpty) {
+      final artwork = File(file.localArtworkPath);
+      if (await artwork.exists()) {
+        try {
+          await artwork.delete();
+        } catch (_) {
+          // Ignore failures while cleaning up.
+        }
+      }
+    }
+    final parsed = await _readHistory();
+    parsed.removeWhere((entry) => _isSameResourceEntry(entry, file));
+    await _setHistory(parsed);
+  }
+
   Future<void> _saveToHistory(DownloadedFile file) async {
     final parsed = await _readHistory();
     parsed.removeWhere((entry) => _isSameResourceEntry(entry, file));

--- a/lib/src/features/downloads/presentation/download_progress_banner.dart
+++ b/lib/src/features/downloads/presentation/download_progress_banner.dart
@@ -87,18 +87,28 @@ class _DownloadsExpandedList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: downloads
-          .map(
-            (download) => Padding(
-              padding: const EdgeInsets.only(bottom: 8),
-              child: _DownloadProgressRow(
-                download: download,
-                onCancel: onCancel,
-              ),
-            ),
-          )
-          .toList(),
+    final maxHeight = MediaQuery.sizeOf(context).height * 0.4;
+
+    return ConstrainedBox(
+      constraints: BoxConstraints(maxHeight: maxHeight),
+      child: Scrollbar(
+        thumbVisibility: downloads.length > 1,
+        child: SingleChildScrollView(
+          child: Column(
+            children: downloads
+                .map(
+                  (download) => Padding(
+                    padding: const EdgeInsets.only(bottom: 8),
+                    child: _DownloadProgressRow(
+                      download: download,
+                      onCancel: onCancel,
+                    ),
+                  ),
+                )
+                .toList(),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/src/features/downloads/presentation/download_progress_banner.dart
+++ b/lib/src/features/downloads/presentation/download_progress_banner.dart
@@ -1,0 +1,146 @@
+import 'package:fcd_app/src/features/downloads/presentation/download_task_controller.dart';
+import 'package:flutter/material.dart';
+
+class DownloadProgressBanner extends StatelessWidget {
+  const DownloadProgressBanner({
+    super.key,
+    required this.controller,
+    required this.expanded,
+    required this.onToggle,
+  });
+
+  static const Color _bannerColor = Color(0xFFFFF5E8);
+  static const Color _bannerBorderColor = Color(0xFFE8DACA);
+
+  final DownloadTaskController controller;
+  final bool expanded;
+  final VoidCallback onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    final downloads = controller.activeDownloads;
+    final overallProgress = controller.overallProgress;
+    final overallPercent =
+        (overallProgress.clamp(0.0, 1.0) * 100).toStringAsFixed(0);
+    final count = downloads.length;
+    final label = count == 1
+        ? 'Descargando 1 archivo'
+        : 'Descargando $count archivos';
+
+    return Material(
+      color: _bannerColor,
+      child: SafeArea(
+        bottom: false,
+        child: InkWell(
+          onTap: onToggle,
+          child: Container(
+            width: double.infinity,
+            padding: const EdgeInsets.fromLTRB(14, 8, 14, 10),
+            decoration: const BoxDecoration(
+              border: Border(bottom: BorderSide(color: _bannerBorderColor)),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Row(
+                  children: <Widget>[
+                    Expanded(
+                      child: Text(
+                        '$label · $overallPercent%',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                    ),
+                    Icon(
+                      expanded
+                          ? Icons.expand_less_rounded
+                          : Icons.expand_more_rounded,
+                      size: 20,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 6),
+                LinearProgressIndicator(value: overallProgress.clamp(0.0, 1.0)),
+                if (expanded) ...<Widget>[
+                  const SizedBox(height: 10),
+                  _DownloadsExpandedList(
+                    downloads: downloads,
+                    onCancel: controller.cancelDownload,
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DownloadsExpandedList extends StatelessWidget {
+  const _DownloadsExpandedList({required this.downloads, required this.onCancel});
+
+  final List<DownloadTaskSnapshot> downloads;
+  final void Function(String resourceId) onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: downloads
+          .map(
+            (download) => Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: _DownloadProgressRow(
+                download: download,
+                onCancel: onCancel,
+              ),
+            ),
+          )
+          .toList(),
+    );
+  }
+}
+
+class _DownloadProgressRow extends StatelessWidget {
+  const _DownloadProgressRow({required this.download, required this.onCancel});
+
+  final DownloadTaskSnapshot download;
+  final void Function(String resourceId) onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    final percent =
+        (download.progress.clamp(0.0, 1.0) * 100).toStringAsFixed(0);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Row(
+          children: <Widget>[
+            Expanded(
+              child: Text(
+                '${download.resourceName} · $percent%',
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+              ),
+            ),
+            IconButton(
+              onPressed: () => onCancel(download.resourceId),
+              icon: const Icon(Icons.close_rounded),
+              tooltip: 'Cancelar descarga',
+              visualDensity: VisualDensity.compact,
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints(minWidth: 28, minHeight: 28),
+            ),
+          ],
+        ),
+        const SizedBox(height: 4),
+        LinearProgressIndicator(value: download.progress.clamp(0.0, 1.0)),
+      ],
+    );
+  }
+}

--- a/lib/src/features/downloads/presentation/download_task_controller.dart
+++ b/lib/src/features/downloads/presentation/download_task_controller.dart
@@ -36,6 +36,7 @@ class _DownloadTaskState {
     required this.resourceId,
     required this.resourceName,
     required this.cancelToken,
+    required this.filePath,
   })
       : receivedBytes = 0,
         totalBytes = 0,
@@ -44,6 +45,7 @@ class _DownloadTaskState {
   final String resourceId;
   final String resourceName;
   final CancelToken cancelToken;
+  final String filePath;
   int receivedBytes;
   int totalBytes;
   double progress;
@@ -119,12 +121,17 @@ class DownloadTaskController extends ChangeNotifier {
     final resourceName = resource.name.trim().isEmpty
         ? _defaultResourceName
         : resource.name;
-  _activeDownloads[resourceId] = _DownloadTaskState(
-    resourceId: resourceId,
-    resourceName: resourceName,
-    cancelToken: CancelToken(),
-  );
-  notifyListeners();
+    
+    // Get the file path before starting download so we can clean up on cancel
+    final filePath = await _downloadRepository.getDownloadFilePath(resource);
+    
+    _activeDownloads[resourceId] = _DownloadTaskState(
+      resourceId: resourceId,
+      resourceName: resourceName,
+      cancelToken: CancelToken(),
+      filePath: filePath,
+    );
+    notifyListeners();
 
     try {
       var alreadyDownloaded = false;
@@ -183,7 +190,11 @@ class DownloadTaskController extends ChangeNotifier {
 
   void cancelDownload(String resourceId) {
     final entry = _activeDownloads.remove(resourceId);
-    entry?.cancelToken.cancel();
+    if (entry != null) {
+      entry.cancelToken.cancel();
+      // Clean up the partial download file asynchronously
+      _downloadRepository.deletePartialDownload(entry.filePath);
+    }
     notifyListeners();
   }
 

--- a/lib/src/features/downloads/presentation/download_task_controller.dart
+++ b/lib/src/features/downloads/presentation/download_task_controller.dart
@@ -5,7 +5,7 @@ import 'package:fcd_app/src/features/courses/data/models/lesson_resource.dart';
 import 'package:fcd_app/src/features/downloads/data/repositories/download_repository.dart';
 import 'package:flutter/foundation.dart';
 
-enum DownloadTaskStatus { completed, alreadyDownloaded, failed, busy }
+enum DownloadTaskStatus { completed, alreadyDownloaded, failed, busy, canceled }
 
 class DownloadTaskResult {
   const DownloadTaskResult({required this.status, this.file, this.error});
@@ -164,7 +164,7 @@ class DownloadTaskController extends ChangeNotifier {
       );
     } on DioException catch (error) {
       if (error.type == DioExceptionType.cancel) {
-        return const DownloadTaskResult(status: DownloadTaskStatus.failed);
+        return const DownloadTaskResult(status: DownloadTaskStatus.canceled);
       }
       return DownloadTaskResult(
         status: DownloadTaskStatus.failed,

--- a/lib/src/features/downloads/presentation/download_task_controller.dart
+++ b/lib/src/features/downloads/presentation/download_task_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:dio/dio.dart';
 import 'package:fcd_app/src/features/courses/data/models/lesson_resource.dart';
 import 'package:fcd_app/src/features/downloads/data/repositories/download_repository.dart';
 import 'package:flutter/foundation.dart';
@@ -14,6 +15,50 @@ class DownloadTaskResult {
   final Object? error;
 }
 
+class DownloadTaskSnapshot {
+  const DownloadTaskSnapshot({
+    required this.resourceId,
+    required this.resourceName,
+    required this.receivedBytes,
+    required this.totalBytes,
+    required this.progress,
+  });
+
+  final String resourceId;
+  final String resourceName;
+  final int receivedBytes;
+  final int totalBytes;
+  final double progress;
+}
+
+class _DownloadTaskState {
+  _DownloadTaskState({
+    required this.resourceId,
+    required this.resourceName,
+    required this.cancelToken,
+  })
+      : receivedBytes = 0,
+        totalBytes = 0,
+        progress = 0;
+
+  final String resourceId;
+  final String resourceName;
+  final CancelToken cancelToken;
+  int receivedBytes;
+  int totalBytes;
+  double progress;
+
+  DownloadTaskSnapshot toSnapshot() {
+    return DownloadTaskSnapshot(
+      resourceId: resourceId,
+      resourceName: resourceName,
+      receivedBytes: receivedBytes,
+      totalBytes: totalBytes,
+      progress: progress,
+    );
+  }
+}
+
 class DownloadTaskController extends ChangeNotifier {
   static const String _defaultResourceName = 'Archivo';
 
@@ -22,48 +67,91 @@ class DownloadTaskController extends ChangeNotifier {
 
   final DownloadRepository _downloadRepository;
 
-  bool _isDownloading = false;
-  double _progress = 0;
-  String _resourceName = '';
+  final Map<String, _DownloadTaskState> _activeDownloads =
+      <String, _DownloadTaskState>{};
 
-  bool get isDownloading => _isDownloading;
-  double get progress => _progress;
-  String get resourceName => _resourceName;
+  bool get hasActiveDownloads => _activeDownloads.isNotEmpty;
+  List<DownloadTaskSnapshot> get activeDownloads =>
+      _activeDownloads.values.map((entry) => entry.toSnapshot()).toList();
+
+  int get overallReceivedBytes {
+    var total = 0;
+    for (final entry in _activeDownloads.values) {
+      total += entry.receivedBytes;
+    }
+    return total;
+  }
+
+  int get overallTotalBytes {
+    var total = 0;
+    for (final entry in _activeDownloads.values) {
+      total += entry.totalBytes;
+    }
+    return total;
+  }
+
+  double get overallProgress {
+    final total = overallTotalBytes;
+    if (total <= 0) {
+      return 0;
+    }
+    final raw = overallReceivedBytes / total;
+    if (!raw.isFinite) {
+      return 0;
+    }
+    return raw.clamp(0.0, 1.0);
+  }
+
+  bool isDownloadingResource(LessonResource resource) {
+    return _activeDownloads.containsKey(_resourceId(resource));
+  }
 
   Future<DownloadTaskResult> downloadResource(
     LessonResource resource, {
     String courseName = '',
     String lessonName = '',
   }) async {
-    if (_isDownloading) {
+    final resourceId = _resourceId(resource);
+    if (_activeDownloads.containsKey(resourceId)) {
       return const DownloadTaskResult(status: DownloadTaskStatus.busy);
     }
 
-    _isDownloading = true;
-    _progress = 0;
-    _resourceName = resource.name.trim().isEmpty
+    final resourceName = resource.name.trim().isEmpty
         ? _defaultResourceName
         : resource.name;
-    notifyListeners();
+  _activeDownloads[resourceId] = _DownloadTaskState(
+    resourceId: resourceId,
+    resourceName: resourceName,
+    cancelToken: CancelToken(),
+  );
+  notifyListeners();
 
     try {
       var alreadyDownloaded = false;
+      final cancelToken = _activeDownloads[resourceId]?.cancelToken;
       final file = await _downloadRepository.downloadResource(
         resource,
         courseName: courseName,
         lessonName: lessonName,
+        cancelToken: cancelToken,
         onAlreadyDownloaded: () {
           alreadyDownloaded = true;
         },
         onProgress: (received, total) {
-          if (total <= 0) {
+          final entry = _activeDownloads[resourceId];
+          if (entry == null) {
             return;
           }
-          final raw = received / total;
-          if (!raw.isFinite) {
-            return;
+          final normalizedTotal = total > 0 ? total : 0;
+          final normalizedReceived = received < 0 ? 0 : received;
+          entry.totalBytes = normalizedTotal;
+          entry.receivedBytes = normalizedReceived;
+          if (normalizedTotal > 0) {
+            final raw = normalizedReceived / normalizedTotal;
+            entry.progress = raw.isFinite ? raw.clamp(0.0, 1.0) : 0;
+          } else {
+            entry.progress = 0;
           }
-          _progress = raw.clamp(0.0, 1.0);
           notifyListeners();
         },
       );
@@ -74,15 +162,32 @@ class DownloadTaskController extends ChangeNotifier {
             : DownloadTaskStatus.completed,
         file: file,
       );
+    } on DioException catch (error) {
+      if (error.type == DioExceptionType.cancel) {
+        return const DownloadTaskResult(status: DownloadTaskStatus.failed);
+      }
+      return DownloadTaskResult(
+        status: DownloadTaskStatus.failed,
+        error: error,
+      );
     } catch (error) {
       return DownloadTaskResult(
         status: DownloadTaskStatus.failed,
         error: error,
       );
     } finally {
-      _isDownloading = false;
-      _progress = 0;
+      _activeDownloads.remove(resourceId);
       notifyListeners();
     }
+  }
+
+  void cancelDownload(String resourceId) {
+    final entry = _activeDownloads.remove(resourceId);
+    entry?.cancelToken.cancel();
+    notifyListeners();
+  }
+
+  String _resourceId(LessonResource resource) {
+    return '${resource.type.name}:${resource.url}';
   }
 }

--- a/lib/src/features/downloads/presentation/downloads_page.dart
+++ b/lib/src/features/downloads/presentation/downloads_page.dart
@@ -42,6 +42,7 @@ class _DownloadsPageState extends State<DownloadsPage> {
   late final DownloadTaskController _downloadTaskController;
   final List<DownloadedFile> _pendingDeletes = <DownloadedFile>[];
   int _deleteSequence = 0;
+  ScaffoldMessengerState? _scaffoldMessenger;
 
   bool _loading = true;
   bool _wasDownloading = false;
@@ -61,8 +62,14 @@ class _DownloadsPageState extends State<DownloadsPage> {
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _scaffoldMessenger = ScaffoldMessenger.of(context);
+  }
+
+  @override
   void dispose() {
-    ScaffoldMessenger.of(context).clearSnackBars();
+    _scaffoldMessenger?.clearSnackBars();
     _downloadTaskController.removeListener(_handleDownloadTaskChange);
     super.dispose();
   }
@@ -189,7 +196,11 @@ class _DownloadsPageState extends State<DownloadsPage> {
     }
 
     setState(() {
-      _files = cleanupResult.files;
+      // Filter out pending deletes to prevent reappearing during undo window
+      _files = cleanupResult.files
+          .where((file) => !_pendingDeletes.any(
+              (pending) => pending.localPath == file.localPath))
+          .toList();
       _loading = false;
       _info = cleanupResult.removed > 0
           ? 'Se limpiaron ${cleanupResult.removed} archivo(s) inexistente(s) del historial.'

--- a/lib/src/features/downloads/presentation/downloads_page.dart
+++ b/lib/src/features/downloads/presentation/downloads_page.dart
@@ -40,6 +40,8 @@ class DownloadsPage extends StatefulWidget {
 class _DownloadsPageState extends State<DownloadsPage> {
   late final DownloadRepository _downloadRepository;
   late final DownloadTaskController _downloadTaskController;
+  final List<DownloadedFile> _pendingDeletes = <DownloadedFile>[];
+  int _deleteSequence = 0;
 
   bool _loading = true;
   bool _wasDownloading = false;
@@ -53,13 +55,14 @@ class _DownloadsPageState extends State<DownloadsPage> {
       apiClient: context.read<SessionController>().apiClient,
     );
     _downloadTaskController = context.read<DownloadTaskController>();
-    _wasDownloading = _downloadTaskController.isDownloading;
+    _wasDownloading = _downloadTaskController.hasActiveDownloads;
     _downloadTaskController.addListener(_handleDownloadTaskChange);
     _load();
   }
 
   @override
   void dispose() {
+    ScaffoldMessenger.of(context).clearSnackBars();
     _downloadTaskController.removeListener(_handleDownloadTaskChange);
     super.dispose();
   }
@@ -162,6 +165,7 @@ class _DownloadsPageState extends State<DownloadsPage> {
                     onPlayAudio: () => _openAudio(entryItem.file),
                     onPlayVideo: () => _playVideo(entryItem.file),
                     onOpen: () => _open(entryItem.file),
+                    onDelete: () => _deleteEntry(entryItem.file),
                   ),
                 );
               },
@@ -194,11 +198,11 @@ class _DownloadsPageState extends State<DownloadsPage> {
   }
 
   void _handleDownloadTaskChange() {
-    final isDownloading = _downloadTaskController.isDownloading;
-    if (_wasDownloading && !isDownloading && mounted) {
+    final hasDownloads = _downloadTaskController.hasActiveDownloads;
+    if (_wasDownloading && !hasDownloads && mounted) {
       _load();
     }
-    _wasDownloading = isDownloading;
+    _wasDownloading = hasDownloads;
   }
 
   Future<void> _open(DownloadedFile file) async {
@@ -307,6 +311,66 @@ class _DownloadsPageState extends State<DownloadsPage> {
     }
     await _load();
   }
+
+  void _deleteEntry(DownloadedFile file) {
+    setState(() {
+      _files.removeWhere((entry) => entry.localPath == file.localPath);
+      _pendingDeletes.add(file);
+    });
+
+    final sequence = ++_deleteSequence;
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.clearSnackBars();
+    messenger
+        .showSnackBar(
+          SnackBar(
+            content: Text(
+              _pendingDeletes.length == 1
+                  ? 'Descarga eliminada.'
+                  : 'Se eliminaron ${_pendingDeletes.length} descargas.',
+            ),
+            action: SnackBarAction(
+              label: 'Deshacer',
+              onPressed: _undoDelete,
+            ),
+            duration: const Duration(seconds: 4),
+          ),
+        )
+        .closed
+        .then((reason) {
+          if (reason == SnackBarClosedReason.action ||
+              sequence != _deleteSequence) {
+            return;
+          }
+          _commitPendingDelete();
+        });
+  }
+
+  void _undoDelete() {
+    if (_pendingDeletes.isEmpty) {
+      return;
+    }
+    setState(() {
+      _files.addAll(_pendingDeletes);
+      _files.sort((a, b) => b.downloadedAt.compareTo(a.downloadedAt));
+      _pendingDeletes.clear();
+    });
+  }
+
+  Future<void> _commitPendingDelete() async {
+    if (_pendingDeletes.isEmpty) {
+      return;
+    }
+    final pending = List<DownloadedFile>.from(_pendingDeletes);
+    _pendingDeletes.clear();
+    for (final entry in pending) {
+      await _downloadRepository.deleteDownload(entry);
+    }
+    if (!mounted) {
+      return;
+    }
+    await _load();
+  }
 }
 
 class _DownloadCard extends StatelessWidget {
@@ -315,12 +379,14 @@ class _DownloadCard extends StatelessWidget {
     required this.onOpen,
     required this.onPlayAudio,
     required this.onPlayVideo,
+    required this.onDelete,
   });
 
   final DownloadedFile file;
   final VoidCallback onOpen;
   final VoidCallback onPlayAudio;
   final VoidCallback onPlayVideo;
+  final VoidCallback onDelete;
 
   @override
   Widget build(BuildContext context) {
@@ -368,18 +434,37 @@ class _DownloadCard extends StatelessWidget {
                   ],
                 ),
               ),
-              if (file.type == 'audio')
-                const Icon(Icons.play_arrow_rounded, color: AppTheme.deepBrown)
-              else if (file.type == 'video')
-                const Icon(
-                  Icons.play_circle_fill_rounded,
-                  color: AppTheme.deepBrown,
-                )
-              else
-                const Icon(
-                  Icons.open_in_new_rounded,
-                  color: AppTheme.deepBrown,
-                ),
+              Row(
+                children: <Widget>[
+                  IconButton(
+                    onPressed: onDelete,
+                    icon: const Icon(Icons.close_rounded),
+                    tooltip: 'Eliminar descarga',
+                    color: AppTheme.mutedText,
+                    visualDensity: VisualDensity.compact,
+                    padding: EdgeInsets.zero,
+                    constraints: const BoxConstraints(
+                      minWidth: 32,
+                      minHeight: 32,
+                    ),
+                  ),
+                  if (file.type == 'audio')
+                    const Icon(
+                      Icons.play_arrow_rounded,
+                      color: AppTheme.deepBrown,
+                    )
+                  else if (file.type == 'video')
+                    const Icon(
+                      Icons.play_circle_fill_rounded,
+                      color: AppTheme.deepBrown,
+                    )
+                  else
+                    const Icon(
+                      Icons.open_in_new_rounded,
+                      color: AppTheme.deepBrown,
+                    ),
+                ],
+              ),
             ],
           ),
         ),

--- a/lib/src/features/home/presentation/home_shell.dart
+++ b/lib/src/features/home/presentation/home_shell.dart
@@ -3,6 +3,7 @@ import 'package:fcd_app/src/features/ai/presentation/ai_chat_page.dart';
 import 'package:fcd_app/src/features/catalog/presentation/catalog_page.dart';
 import 'package:fcd_app/src/features/courses/presentation/courses_page.dart';
 import 'package:fcd_app/src/features/downloads/presentation/downloads_page.dart';
+import 'package:fcd_app/src/features/downloads/presentation/download_progress_banner.dart';
 import 'package:fcd_app/src/features/downloads/presentation/download_task_controller.dart';
 import 'package:fcd_app/src/features/favorites/presentation/favorites_page.dart';
 import 'package:flutter/material.dart';
@@ -20,6 +21,7 @@ class HomeShell extends StatefulWidget {
 class _HomeShellState extends State<HomeShell> {
   int _selectedIndex = 0;
   late final List<ScrollController> _tabScrollControllers;
+  bool _downloadsExpanded = false;
   late final List<Widget> _defaultPages;
 
   static const List<NavigationDestination> _bottomDestinations =
@@ -133,6 +135,17 @@ class _HomeShellState extends State<HomeShell> {
       );
     });
     final downloadController = context.watch<DownloadTaskController>();
+    final hasDownloads = downloadController.hasActiveDownloads;
+    final isDownloadsExpanded = _downloadsExpanded && hasDownloads;
+    if (_downloadsExpanded && !hasDownloads) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          setState(() {
+            _downloadsExpanded = false;
+          });
+        }
+      });
+    }
     final content = IndexedStack(index: _selectedIndex, children: wrappedPages);
     final shellBody = isTablet
         ? Row(
@@ -150,6 +163,16 @@ class _HomeShellState extends State<HomeShell> {
             ],
           )
         : SafeArea(child: content);
+
+    final shellContent = NotificationListener<ScrollNotification>(
+      onNotification: (notification) {
+        if (isDownloadsExpanded && notification is ScrollStartNotification) {
+          _collapseDownloadsBanner();
+        }
+        return false;
+      },
+      child: shellBody,
+    );
 
     return Scaffold(
       appBar: AppBar(
@@ -173,14 +196,27 @@ class _HomeShellState extends State<HomeShell> {
           ],
         ),
       ),
-      body: Column(
+      body: Stack(
         children: <Widget>[
-          if (downloadController.isDownloading)
-            _BackgroundDownloadBanner(
-              progress: downloadController.progress,
-              resourceName: downloadController.resourceName,
+          Positioned.fill(child: shellContent),
+          if (isDownloadsExpanded)
+            Positioned.fill(
+              child: GestureDetector(
+                onTap: _collapseDownloadsBanner,
+                behavior: HitTestBehavior.translucent,
+              ),
             ),
-          Expanded(child: shellBody),
+          if (hasDownloads)
+            Positioned(
+              top: 0,
+              left: 0,
+              right: 0,
+              child: DownloadProgressBanner(
+                controller: downloadController,
+                expanded: isDownloadsExpanded,
+                onToggle: _toggleDownloadsBanner,
+              ),
+            ),
         ],
       ),
       bottomNavigationBar: isTablet
@@ -263,48 +299,19 @@ class _HomeShellState extends State<HomeShell> {
       curve: Curves.easeOutCubic,
     );
   }
-}
 
-class _BackgroundDownloadBanner extends StatelessWidget {
-  const _BackgroundDownloadBanner({
-    required this.progress,
-    required this.resourceName,
-  });
+  void _toggleDownloadsBanner() {
+    setState(() {
+      _downloadsExpanded = !_downloadsExpanded;
+    });
+  }
 
-  static const Color _bannerColor = Color(0xFFFFF5E8);
-  static const Color _bannerBorderColor = Color(0xFFE8DACA);
-
-  final double progress;
-  final String resourceName;
-
-  @override
-  Widget build(BuildContext context) {
-    final percent = (progress.clamp(0.0, 1.0) * 100).toStringAsFixed(0);
-    return Material(
-      color: _bannerColor,
-      child: SafeArea(
-        bottom: false,
-        child: Container(
-          width: double.infinity,
-          padding: const EdgeInsets.fromLTRB(14, 8, 14, 10),
-          decoration: const BoxDecoration(
-            border: Border(bottom: BorderSide(color: _bannerBorderColor)),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Text(
-                'Descargando en segundo plano: $resourceName ($percent%)',
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: Theme.of(context).textTheme.bodySmall,
-              ),
-              const SizedBox(height: 6),
-              LinearProgressIndicator(value: progress.clamp(0.0, 1.0)),
-            ],
-          ),
-        ),
-      ),
-    );
+  void _collapseDownloadsBanner() {
+    if (!_downloadsExpanded) {
+      return;
+    }
+    setState(() {
+      _downloadsExpanded = false;
+    });
   }
 }

--- a/test/src/features/downloads/presentation/download_task_controller_test.dart
+++ b/test/src/features/downloads/presentation/download_task_controller_test.dart
@@ -25,8 +25,9 @@ void main() {
 
       expect(result.status, DownloadTaskStatus.completed);
       expect(result.file, isNotNull);
-      expect(controller.isDownloading, isFalse);
-      expect(controller.progress, 0);
+      expect(controller.hasActiveDownloads, isFalse);
+      expect(controller.activeDownloads, isEmpty);
+      expect(controller.overallProgress, 0);
 
       await tempDir.delete(recursive: true);
     });


### PR DESCRIPTION
## Summary
- Replace the single global download state with a multi-resource tracker so downloads can run concurrently and progress is aggregated by total bytes.
- Add an overlay download banner that can expand to show per-resource progress and allow canceling an individual download.
- Update course and downloads flows so "already downloaded" resources are surfaced clearly and users can remove items with undoable deletes.

## Details
This change reworks how downloads are represented across the app so multiple resources can download in parallel without blocking the UI. The prior model had a single boolean/progress pair, which forced the download button to block all resources and limited progress display to one file. We now keep an in-memory map of active download tasks keyed by resource id. That allows concurrent downloads, provides accurate byte-weighted aggregate progress, and makes it possible to show per-resource progress in an expanded banner.

A new `DownloadProgressBanner` component handles the display. In the compact state it shows the total progress (weighted by bytes) and number of files; in the expanded state it lists each download with its own progress and a small cancel button. The banner is rendered as an overlay (so it does not push content down) and collapses on scroll start to avoid blocking navigation. We also added tap-to-collapse handling when expanded, which keeps the UI responsive.

In the course player we now show download progress while staying inside the lesson, rather than only after navigating away. The download button is per-resource: it disables only for the resource currently downloading, and when a resource is already downloaded it shows "Ya descargado" and stays disabled to prevent redundant requests. Resource rows also show a downloaded checkmark so users can see what is already on disk without trying to download again. Downloaded status is refreshed on route return and app resume, and the check matching normalizes URLs (stripping query/fragment) to avoid mismatches with signed URLs. We reuse a single audio player instance to avoid `just_audio_background` errors that arise from rapid resource switching.

The downloads tab now supports individual delete actions with a snackbar undo. Deletes are batched: multiple rapid deletions are queued, a single snackbar reflects the count, and the actual disk/history deletion occurs only after the snackbar closes without undo. This avoids flicker, keeps the list stable, and matches the desired "delete after snackbar" behavior. Cleanup removes both the file and any cached artwork, then updates the download history.

## Why this approach
- **Concurrency**: a per-resource download map is required to allow multiple downloads in progress at once without disabling unrelated resources.
- **Accurate progress**: byte-weighted aggregation avoids misleading progress when files have different sizes.
- **Overlay banner**: keeps the UI layout stable and avoids shifting content, while still providing global visibility and expand/collapse detail.
- **Route-aware refresh**: ensures downloaded checks persist across navigation and match the history/disk state.
- **Undo-safe deletion**: delaying deletion until snackbar close ensures the user can truly revert the action.

## Files changed
- `lib/src/features/downloads/presentation/download_task_controller.dart`
- `lib/src/features/downloads/presentation/download_progress_banner.dart`
- `lib/src/features/home/presentation/home_shell.dart`
- `lib/src/features/courses/presentation/course_player_page.dart`
- `lib/src/features/downloads/presentation/downloads_page.dart`
- `lib/src/features/downloads/data/repositories/download_repository.dart`
- `lib/src/core/navigation/route_observer.dart`
- `lib/src/app.dart`

## How to test
1. Start two downloads in the same course: the button should only disable for each resource, and the banner should show aggregated progress.
2. Expand the banner: each download shows its own progress and a cancel (x) button that stops that download only.
3. In the downloads tab, delete multiple items quickly: a single snackbar should appear with an undo. If you do not undo, the files should be removed from disk and history.
4. Re-open a course after navigating away: already downloaded resources should show the checkmark and the button should read "Ya descargado".