### PR TITLE
Fix video orientation policy on iOS

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -10,29 +10,34 @@ import UIKit
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    if let registrar = self.registrar(forPlugin: "OrientationLockPlugin") {
-      let channel = FlutterMethodChannel(
-        name: "orientation_lock",
-        binaryMessenger: registrar.messenger()
-      )
-      channel.setMethodCallHandler { call, result in
-        if call.method == "setOrientationMask" {
-          if let args = call.arguments as? [String: Any],
-             let mask = args["mask"] as? String {
-            AppDelegate.updateOrientationMask(mask)
-            result(nil as Any?)
-          } else {
-            result(
-              FlutterError(
-                code: "bad_args",
-                message: "Missing orientation mask",
-                details: nil
-              )
-            )
-          }
+    guard let registrar = self.registrar(forPlugin: "OrientationLockPlugin") else {
+      let message = "Failed to register orientation_lock channel: registrar(forPlugin:) returned nil for OrientationLockPlugin."
+      NSLog("%@", message)
+      assertionFailure(message)
+      return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    }
+
+    let channel = FlutterMethodChannel(
+      name: "orientation_lock",
+      binaryMessenger: registrar.messenger()
+    )
+    channel.setMethodCallHandler { call, result in
+      if call.method == "setOrientationMask" {
+        if let args = call.arguments as? [String: Any],
+           let mask = args["mask"] as? String {
+          AppDelegate.updateOrientationMask(mask)
+          result(nil as Any?)
         } else {
-          result(FlutterMethodNotImplemented)
+          result(
+            FlutterError(
+              code: "bad_args",
+              message: "Missing orientation mask",
+              details: nil
+            )
+          )
         }
+      } else {
+        result(FlutterMethodNotImplemented)
       }
     }
 

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -3,14 +3,90 @@ import UIKit
 
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
+  static var orientationMask: UIInterfaceOrientationMask =
+    UIDevice.current.userInterfaceIdiom == .pad ? .all : .portrait
+
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    if let registrar = self.registrar(forPlugin: "OrientationLockPlugin") {
+      let channel = FlutterMethodChannel(
+        name: "orientation_lock",
+        binaryMessenger: registrar.messenger()
+      )
+      channel.setMethodCallHandler { call, result in
+        if call.method == "setOrientationMask" {
+          if let args = call.arguments as? [String: Any],
+             let mask = args["mask"] as? String {
+            AppDelegate.updateOrientationMask(mask)
+            result(nil as Any?)
+          } else {
+            result(
+              FlutterError(
+                code: "bad_args",
+                message: "Missing orientation mask",
+                details: nil
+              )
+            )
+          }
+        } else {
+          result(FlutterMethodNotImplemented)
+        }
+      }
+    }
+
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+  }
+
+  override func application(
+    _ application: UIApplication,
+    supportedInterfaceOrientationsFor window: UIWindow?
+  ) -> UIInterfaceOrientationMask {
+    return AppDelegate.orientationMask
+  }
+
+  static func updateOrientationMask(_ mask: String) {
+    switch mask {
+    case "portrait":
+      orientationMask = .portrait
+      forceDeviceOrientation(.portrait)
+    case "landscape":
+      orientationMask = .landscape
+      forceDeviceOrientation(.landscape)
+    case "all":
+      orientationMask = .all
+    default:
+      break
+    }
+
+    DispatchQueue.main.async {
+      for scene in UIApplication.shared.connectedScenes {
+        guard let windowScene = scene as? UIWindowScene else {
+          continue
+        }
+        for window in windowScene.windows {
+          if #available(iOS 16.0, *) {
+            window.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
+          }
+        }
+      }
+      UIViewController.attemptRotationToDeviceOrientation()
+    }
+  }
+
+  private static func forceDeviceOrientation(_ mask: UIInterfaceOrientationMask) {
+    guard UIDevice.current.userInterfaceIdiom == .phone else {
+      return
+    }
+    if mask.contains(.landscapeRight) || mask.contains(.landscapeLeft) {
+      UIDevice.current.setValue(UIInterfaceOrientation.landscapeRight.rawValue, forKey: "orientation")
+    } else if mask.contains(.portrait) {
+      UIDevice.current.setValue(UIInterfaceOrientation.portrait.rawValue, forKey: "orientation")
+    }
   }
 }

--- a/ios/Runner/SceneDelegate.swift
+++ b/ios/Runner/SceneDelegate.swift
@@ -2,5 +2,4 @@ import Flutter
 import UIKit
 
 class SceneDelegate: FlutterSceneDelegate {
-
 }

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -1,4 +1,5 @@
 import 'package:fcd_app/src/core/theme/app_theme.dart';
+import 'package:fcd_app/src/core/utils/orientation_policy.dart';
 import 'package:fcd_app/src/core/navigation/route_observer.dart';
 import 'package:fcd_app/src/features/auth/presentation/login_page.dart';
 import 'package:fcd_app/src/features/home/presentation/home_shell.dart';
@@ -17,7 +18,7 @@ class FcdApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       theme: AppTheme.light(),
       navigatorObservers: <NavigatorObserver>[routeObserver],
-      home: const _BootstrapGate(),
+      home: const OrientationPolicyGate(child: _BootstrapGate()),
     );
   }
 }

--- a/lib/src/core/utils/orientation_policy.dart
+++ b/lib/src/core/utils/orientation_policy.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class OrientationPolicy {
+  static const double _tabletShortestSide = 600;
+  static const MethodChannel _channel = MethodChannel('orientation_lock');
+  static bool _isVideoFullscreenActive = false;
+
+  static bool isTablet(BuildContext context) {
+    final size = MediaQuery.of(context).size;
+    return isTabletForSize(size);
+  }
+
+  static bool isTabletForSize(Size size) {
+    return size.shortestSide >= _tabletShortestSide;
+  }
+
+  static bool get isVideoFullscreenActive => _isVideoFullscreenActive;
+
+  static void setVideoFullscreenActive(bool isActive) {
+    _isVideoFullscreenActive = isActive;
+  }
+
+  static Future<void> applyDefault({required bool isTablet}) {
+    if (!isTablet && _isVideoFullscreenActive) {
+      return Future<void>.value();
+    }
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      return _setIosOrientationMask(
+        isTablet ? 'all' : 'portrait',
+        isTablet: isTablet,
+      );
+    }
+    return SystemChrome.setPreferredOrientations(
+      isTablet
+          ? DeviceOrientation.values
+          : <DeviceOrientation>[DeviceOrientation.portraitUp],
+    );
+  }
+
+  static Future<void> applyDefaultOrientations(BuildContext context) {
+    return applyDefault(isTablet: isTablet(context));
+  }
+
+  static Future<void> applyVideoFullscreen({required bool isTablet}) {
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      return _setIosOrientationMask(
+        isTablet ? 'all' : 'landscape',
+        isTablet: isTablet,
+      );
+    }
+    return SystemChrome.setPreferredOrientations(
+      isTablet
+          ? DeviceOrientation.values
+          : <DeviceOrientation>[
+              DeviceOrientation.landscapeLeft,
+              DeviceOrientation.landscapeRight,
+            ],
+    );
+  }
+
+  static Future<void> _setIosOrientationMask(
+    String mask, {
+    required bool isTablet,
+  }) async {
+    await _channel.invokeMethod<void>(
+      'setOrientationMask',
+      <String, String>{'mask': mask},
+    );
+    await SystemChrome.setPreferredOrientations(
+      isTablet
+          ? DeviceOrientation.values
+          : mask == 'landscape'
+              ? <DeviceOrientation>[
+                  DeviceOrientation.landscapeLeft,
+                  DeviceOrientation.landscapeRight,
+                ]
+              : <DeviceOrientation>[DeviceOrientation.portraitUp],
+    );
+  }
+
+  static Future<void> applyVideoFullscreenOrientations(
+    BuildContext context,
+  ) {
+    return applyVideoFullscreen(isTablet: isTablet(context));
+  }
+}
+
+class OrientationPolicyGate extends StatefulWidget {
+  const OrientationPolicyGate({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  State<OrientationPolicyGate> createState() => _OrientationPolicyGateState();
+}
+
+class _OrientationPolicyGateState extends State<OrientationPolicyGate> {
+  bool? _isTablet;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _applyPolicyIfNeeded();
+  }
+
+  @override
+  void didUpdateWidget(OrientationPolicyGate oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _applyPolicyIfNeeded();
+  }
+
+  void _applyPolicyIfNeeded() {
+    final isTablet = OrientationPolicy.isTablet(context);
+    if (_isTablet == isTablet) {
+      return;
+    }
+    _isTablet = isTablet;
+    if (!OrientationPolicy.isVideoFullscreenActive) {
+      OrientationPolicy.applyDefault(isTablet: isTablet);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/lib/src/core/utils/orientation_policy.dart
+++ b/lib/src/core/utils/orientation_policy.dart
@@ -22,8 +22,11 @@ class OrientationPolicy {
     _isVideoFullscreenActive = isActive;
   }
 
-  static Future<void> applyDefault({required bool isTablet}) {
-    if (!isTablet && _isVideoFullscreenActive) {
+  static Future<void> applyDefault({
+    required bool isTablet,
+    bool ignoreFullscreenFlag = false,
+  }) {
+    if (!ignoreFullscreenFlag && !isTablet && _isVideoFullscreenActive) {
       return Future<void>.value();
     }
     if (defaultTargetPlatform == TargetPlatform.iOS) {

--- a/lib/src/features/courses/presentation/course_player_page.dart
+++ b/lib/src/features/courses/presentation/course_player_page.dart
@@ -1119,6 +1119,9 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
         return;
       case DownloadTaskStatus.alreadyDownloaded:
         await _refreshDownloadedResources();
+        if (!mounted) {
+          return;
+        }
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
             content: Text('Este recurso ya fue descargado previamente.'),

--- a/lib/src/features/courses/presentation/course_player_page.dart
+++ b/lib/src/features/courses/presentation/course_player_page.dart
@@ -173,8 +173,11 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
   @override
   void dispose() {
     if (!_isTablet) {
-      OrientationPolicy.isVideoFullscreenActive = false;
-      OrientationPolicy.applyDefault(isTablet: _isTablet);
+      OrientationPolicy.setVideoFullscreenActive(false);
+      OrientationPolicy.applyDefault(
+        isTablet: _isTablet,
+        ignoreFullscreenFlag: true,
+      );
     }
     routeObserver.unsubscribe(this);
     WidgetsBinding.instance.removeObserver(this);

--- a/lib/src/features/courses/presentation/course_player_page.dart
+++ b/lib/src/features/courses/presentation/course_player_page.dart
@@ -1577,6 +1577,7 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
         handleLifecycle: false,
         autoDispose: false,
         eventListener: _handleVideoEvents,
+        routePageBuilder: _buildFullscreenRoute,
         deviceOrientationsOnFullScreen: _isTablet
             ? DeviceOrientation.values
             : <DeviceOrientation>[
@@ -1600,6 +1601,44 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
     );
 
     return videoController;
+  }
+
+  Widget _buildFullscreenRoute(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    BetterPlayerControllerProvider controllerProvider,
+  ) {
+    return AnimatedBuilder(
+      animation: animation,
+      builder: (context, child) {
+        return Scaffold(
+          resizeToAvoidBottomInset: false,
+          body: Stack(
+            children: <Widget>[
+              Positioned.fill(
+                child: Container(
+                  color: Colors.black,
+                  child: controllerProvider,
+                ),
+              ),
+              SafeArea(
+                child: Align(
+                  alignment: Alignment.topLeft,
+                  child: IconButton(
+                    onPressed: () =>
+                        Navigator.of(context, rootNavigator: true).maybePop(),
+                    icon: const Icon(Icons.arrow_back_rounded),
+                    color: Colors.white,
+                    tooltip: 'Volver',
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
   }
 
   void _handleVideoEvents(BetterPlayerEvent event) {

--- a/lib/src/features/courses/presentation/course_player_page.dart
+++ b/lib/src/features/courses/presentation/course_player_page.dart
@@ -6,6 +6,7 @@ import 'package:fcd_app/src/core/navigation/route_observer.dart';
 import 'package:fcd_app/src/core/storage/favorites_storage.dart';
 import 'package:fcd_app/src/core/storage/progress_storage.dart';
 import 'package:fcd_app/src/core/theme/app_theme.dart';
+import 'package:fcd_app/src/core/utils/orientation_policy.dart';
 import 'package:fcd_app/src/core/widgets/audio_mini_player.dart';
 import 'package:fcd_app/src/core/widgets/audio_player_widget.dart';
 import 'package:fcd_app/src/core/widgets/scrolling_text.dart';
@@ -19,6 +20,7 @@ import 'package:fcd_app/src/features/downloads/presentation/downloaded_audio_pag
 import 'package:fcd_app/src/state/audio_playback_controller.dart';
 import 'package:fcd_app/src/state/session_controller.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:just_audio_background/just_audio_background.dart';
@@ -117,6 +119,7 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
   Timer? _downloadSnackBarTimer;
   bool _reuseSharedAudio = false;
   bool _resumeSharedAudio = false;
+  bool _isTablet = false;
 
   BetterPlayerController? _videoController;
   AudioPlayer? _audioPlayer;
@@ -152,6 +155,13 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
     if (route != null) {
       routeObserver.subscribe(this, route);
     }
+    final isTablet = OrientationPolicy.isTablet(context);
+    if (_isTablet != isTablet) {
+      _isTablet = isTablet;
+      if (!OrientationPolicy.isVideoFullscreenActive) {
+        OrientationPolicy.applyDefault(isTablet: isTablet);
+      }
+    }
     final session = context.read<SessionController>();
     if (_cachedSession == null) {
       session.addListener(_onSessionChanged);
@@ -162,6 +172,9 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
 
   @override
   void dispose() {
+    if (!_isTablet) {
+      OrientationPolicy.applyDefault(isTablet: _isTablet);
+    }
     routeObserver.unsubscribe(this);
     WidgetsBinding.instance.removeObserver(this);
     _saveProgressOnDispose();
@@ -1401,7 +1414,12 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
         ? previousActiveMediaResourceKey
         : null;
 
-    previousVideoController?.dispose(forceDispose: true);
+    if (previousVideoController != null) {
+      if (!_isTablet && previousVideoController.isFullScreen) {
+        OrientationPolicy.setVideoFullscreenActive(true);
+      }
+      previousVideoController.dispose(forceDispose: true);
+    }
     if (!keepExistingAudioPlayer && previousAudioPlayer != null) {
       await previousAudioPlayer.stop();
     }
@@ -1545,12 +1563,22 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
     );
 
     final videoController = BetterPlayerController(
-      const BetterPlayerConfiguration(
+      BetterPlayerConfiguration(
         autoPlay: false,
         fit: BoxFit.contain,
         allowedScreenSleep: false,
         handleLifecycle: false,
         autoDispose: false,
+        eventListener: _handleVideoEvents,
+        deviceOrientationsOnFullScreen: _isTablet
+            ? DeviceOrientation.values
+            : <DeviceOrientation>[
+                DeviceOrientation.landscapeLeft,
+                DeviceOrientation.landscapeRight,
+              ],
+        deviceOrientationsAfterFullScreen: _isTablet
+            ? DeviceOrientation.values
+            : <DeviceOrientation>[DeviceOrientation.portraitUp],
         controlsConfiguration: BetterPlayerControlsConfiguration(
           enableSkips: true,
           enablePlaybackSpeed: true,
@@ -1565,6 +1593,24 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
     );
 
     return videoController;
+  }
+
+  void _handleVideoEvents(BetterPlayerEvent event) {
+    if (_isTablet) {
+      return;
+    }
+    switch (event.betterPlayerEventType) {
+      case BetterPlayerEventType.openFullscreen:
+        OrientationPolicy.setVideoFullscreenActive(true);
+        OrientationPolicy.applyVideoFullscreen(isTablet: _isTablet);
+        break;
+      case BetterPlayerEventType.hideFullscreen:
+        OrientationPolicy.setVideoFullscreenActive(false);
+        OrientationPolicy.applyDefault(isTablet: _isTablet);
+        break;
+      default:
+        break;
+    }
   }
 
   void _startVideoInitializationCheck(

--- a/lib/src/features/courses/presentation/course_player_page.dart
+++ b/lib/src/features/courses/presentation/course_player_page.dart
@@ -173,6 +173,7 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
   @override
   void dispose() {
     if (!_isTablet) {
+      OrientationPolicy.isVideoFullscreenActive = false;
       OrientationPolicy.applyDefault(isTablet: _isTablet);
     }
     routeObserver.unsubscribe(this);

--- a/lib/src/features/downloads/presentation/downloaded_video_page.dart
+++ b/lib/src/features/downloads/presentation/downloaded_video_page.dart
@@ -20,7 +20,6 @@ class _DownloadedVideoPageState extends State<DownloadedVideoPage> {
   BetterPlayerController? _controller;
   String? _error;
   bool _isTablet = false;
-  Size? _lastSize;
   bool _isPreparingController = false;
 
   @override
@@ -37,7 +36,6 @@ class _DownloadedVideoPageState extends State<DownloadedVideoPage> {
       return;
     }
     _isTablet = OrientationPolicy.isTabletForSize(mediaQuery.size);
-    _lastSize = mediaQuery.size;
     if (_controller == null && !_isPreparingController) {
       _prepareController();
     }

--- a/lib/src/features/downloads/presentation/downloaded_video_page.dart
+++ b/lib/src/features/downloads/presentation/downloaded_video_page.dart
@@ -43,6 +43,7 @@ class _DownloadedVideoPageState extends State<DownloadedVideoPage> {
 
   @override
   void dispose() {
+    OrientationPolicy.setVideoFullscreenActive(false);
     OrientationPolicy.applyDefault(isTablet: _isTablet);
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
     _controller?.dispose(forceDispose: true);

--- a/lib/src/features/downloads/presentation/downloaded_video_page.dart
+++ b/lib/src/features/downloads/presentation/downloaded_video_page.dart
@@ -167,8 +167,7 @@ class _DownloadedVideoPageState extends State<DownloadedVideoPage> {
                 child: Align(
                   alignment: Alignment.topLeft,
                   child: IconButton(
-                    onPressed: () =>
-                        Navigator.of(context, rootNavigator: true).maybePop(),
+                    onPressed: () => _exitFullscreenAndPopPage(context),
                     icon: const Icon(Icons.arrow_back_rounded),
                     color: Colors.white,
                     tooltip: 'Volver',
@@ -180,6 +179,16 @@ class _DownloadedVideoPageState extends State<DownloadedVideoPage> {
         );
       },
     );
+  }
+
+  void _exitFullscreenAndPopPage(BuildContext fullscreenContext) {
+    Navigator.of(fullscreenContext, rootNavigator: true).maybePop();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      Navigator.of(context, rootNavigator: true).maybePop();
+    });
   }
 
   @override

--- a/lib/src/features/downloads/presentation/downloaded_video_page.dart
+++ b/lib/src/features/downloads/presentation/downloaded_video_page.dart
@@ -93,6 +93,7 @@ class _DownloadedVideoPageState extends State<DownloadedVideoPage> {
         autoDispose: false,
         fullScreenByDefault: !_isTablet,
         eventListener: _handleVideoEvents,
+        routePageBuilder: _buildFullscreenRoute,
         deviceOrientationsOnFullScreen: _isTablet
             ? DeviceOrientation.values
             : <DeviceOrientation>[
@@ -141,6 +142,44 @@ class _DownloadedVideoPageState extends State<DownloadedVideoPage> {
       default:
         break;
     }
+  }
+
+  Widget _buildFullscreenRoute(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    BetterPlayerControllerProvider controllerProvider,
+  ) {
+    return AnimatedBuilder(
+      animation: animation,
+      builder: (context, child) {
+        return Scaffold(
+          resizeToAvoidBottomInset: false,
+          body: Stack(
+            children: <Widget>[
+              Positioned.fill(
+                child: Container(
+                  color: Colors.black,
+                  child: controllerProvider,
+                ),
+              ),
+              SafeArea(
+                child: Align(
+                  alignment: Alignment.topLeft,
+                  child: IconButton(
+                    onPressed: () =>
+                        Navigator.of(context, rootNavigator: true).maybePop(),
+                    icon: const Icon(Icons.arrow_back_rounded),
+                    color: Colors.white,
+                    tooltip: 'Volver',
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
   }
 
   @override

--- a/lib/src/features/downloads/presentation/downloaded_video_page.dart
+++ b/lib/src/features/downloads/presentation/downloaded_video_page.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:better_player_plus/better_player_plus.dart';
+import 'package:fcd_app/src/core/utils/orientation_policy.dart';
 import 'package:fcd_app/src/core/theme/app_theme.dart';
 import 'package:fcd_app/src/features/downloads/data/models/downloaded_file.dart';
 import 'package:flutter/material.dart';
@@ -18,32 +19,40 @@ class DownloadedVideoPage extends StatefulWidget {
 class _DownloadedVideoPageState extends State<DownloadedVideoPage> {
   BetterPlayerController? _controller;
   String? _error;
+  bool _isTablet = false;
+  Size? _lastSize;
+  bool _isPreparingController = false;
 
   @override
   void initState() {
     super.initState();
-    SystemChrome.setPreferredOrientations(<DeviceOrientation>[
-      DeviceOrientation.landscapeLeft,
-      DeviceOrientation.landscapeRight,
-    ]);
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
-    _prepareController();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final mediaQuery = MediaQuery.maybeOf(context);
+    if (mediaQuery == null) {
+      return;
+    }
+    _isTablet = OrientationPolicy.isTabletForSize(mediaQuery.size);
+    _lastSize = mediaQuery.size;
+    if (_controller == null && !_isPreparingController) {
+      _prepareController();
+    }
   }
 
   @override
   void dispose() {
-    SystemChrome.setPreferredOrientations(<DeviceOrientation>[
-      DeviceOrientation.portraitUp,
-      DeviceOrientation.portraitDown,
-      DeviceOrientation.landscapeLeft,
-      DeviceOrientation.landscapeRight,
-    ]);
+    OrientationPolicy.applyDefault(isTablet: _isTablet);
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
     _controller?.dispose(forceDispose: true);
     super.dispose();
   }
 
   Future<void> _prepareController() async {
+    _isPreparingController = true;
     final localFile = File(widget.file.localPath);
     if (!await localFile.exists()) {
       if (mounted) {
@@ -51,6 +60,7 @@ class _DownloadedVideoPageState extends State<DownloadedVideoPage> {
           _error = 'El archivo ya no existe en el almacenamiento local.';
         });
       }
+      _isPreparingController = false;
       return;
     }
 
@@ -73,12 +83,23 @@ class _DownloadedVideoPageState extends State<DownloadedVideoPage> {
     );
 
     final controller = BetterPlayerController(
-      const BetterPlayerConfiguration(
+      BetterPlayerConfiguration(
         autoPlay: true,
         fit: BoxFit.contain,
         allowedScreenSleep: false,
         handleLifecycle: false,
         autoDispose: false,
+        fullScreenByDefault: !_isTablet,
+        eventListener: _handleVideoEvents,
+        deviceOrientationsOnFullScreen: _isTablet
+            ? DeviceOrientation.values
+            : <DeviceOrientation>[
+                DeviceOrientation.landscapeLeft,
+                DeviceOrientation.landscapeRight,
+              ],
+        deviceOrientationsAfterFullScreen: _isTablet
+            ? DeviceOrientation.values
+            : <DeviceOrientation>[DeviceOrientation.portraitUp],
         controlsConfiguration: BetterPlayerControlsConfiguration(
           enableSkips: true,
           enablePlaybackSpeed: true,
@@ -91,13 +112,32 @@ class _DownloadedVideoPageState extends State<DownloadedVideoPage> {
       ),
       betterPlayerDataSource: dataSource,
     );
-
     if (mounted) {
       setState(() {
         _controller = controller;
       });
+      _isPreparingController = false;
     } else {
       controller.dispose(forceDispose: true);
+      _isPreparingController = false;
+    }
+  }
+
+  void _handleVideoEvents(BetterPlayerEvent event) {
+    if (_isTablet) {
+      return;
+    }
+    switch (event.betterPlayerEventType) {
+      case BetterPlayerEventType.openFullscreen:
+        OrientationPolicy.setVideoFullscreenActive(true);
+        OrientationPolicy.applyVideoFullscreen(isTablet: _isTablet);
+        break;
+      case BetterPlayerEventType.hideFullscreen:
+        OrientationPolicy.setVideoFullscreenActive(false);
+        OrientationPolicy.applyDefault(isTablet: _isTablet);
+        break;
+      default:
+        break;
     }
   }
 

--- a/lib/src/features/downloads/presentation/downloaded_video_page.dart
+++ b/lib/src/features/downloads/presentation/downloaded_video_page.dart
@@ -44,7 +44,10 @@ class _DownloadedVideoPageState extends State<DownloadedVideoPage> {
   @override
   void dispose() {
     OrientationPolicy.setVideoFullscreenActive(false);
-    OrientationPolicy.applyDefault(isTablet: _isTablet);
+    OrientationPolicy.applyDefault(
+      isTablet: _isTablet,
+      ignoreFullscreenFlag: true,
+    );
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
     _controller?.dispose(forceDispose: true);
     super.dispose();


### PR DESCRIPTION
## Summary
- enforce a device-type-aware orientation policy so phones stay portrait outside fullscreen video, while tablets remain fully rotatable
- add a native iOS orientation mask that is updated via method channel to align UIInterfaceOrientation support with the fullscreen state
- keep BetterPlayer fullscreen transitions in sync with both Flutter and native orientation state to avoid UIScene orientation conflicts
- keep a visible back affordance in fullscreen video so users can exit without toggling fullscreen off
- ensure the fullscreen back button on downloaded videos exits fullscreen and returns to the downloads tab in one tap

## Technical details
- **OrientationPolicy (Flutter)**
  - Introduced `lib/src/core/utils/orientation_policy.dart` to centralize orientation behavior.
  - Phone baseline: portrait only. Tablet baseline: all orientations.
  - Fullscreen video on phone: landscape-only (left/right), restored to portrait on fullscreen exit.
  - iOS path now invokes a `MethodChannel` (`orientation_lock`) to set an iOS-side orientation mask and then mirrors that choice with `SystemChrome.setPreferredOrientations` to keep Flutter’s orientation state aligned with UIKit.
  - Added a `OrientationPolicyGate` wrapper in `lib/src/app.dart` so default orientation policy is applied early and remains consistent as device class changes.

- **BetterPlayer integration (Flutter)**
  - Course player: `lib/src/features/courses/presentation/course_player_page.dart`
    - Added a per-page tablet check and applied default orientation if not fullscreen.
    - Configured `BetterPlayerConfiguration` to pass fullscreen orientation lists (`deviceOrientationsOnFullScreen`, `deviceOrientationsAfterFullScreen`) appropriate to phone vs tablet.
    - Wired `eventListener` for `openFullscreen` / `hideFullscreen` to toggle orientation policy and update native mask on iOS.
    - Added a custom `routePageBuilder` so fullscreen video renders with a top-left back button that pops the fullscreen route via the root navigator.
    - Added a `mounted` recheck after refreshing downloads to avoid `BuildContext` usage across async gaps.
  - Downloaded video: `lib/src/features/downloads/presentation/downloaded_video_page.dart`
    - Same fullscreen orientation configuration as course player.
    - `fullScreenByDefault` on phones to enter fullscreen automatically for downloaded videos.
    - Event listener mirrors course player to keep native mask + Flutter state in sync.
    - Added the same fullscreen `routePageBuilder` overlay for a persistent back button.
    - Updated the fullscreen back button handler to pop the fullscreen route and then pop the downloads page on the next frame, so users return to the downloads list in one tap.
    - Removed an unused `_lastSize` field after the orientation gate changed initialization flow.

- **iOS native orientation control**
  - `ios/Runner/AppDelegate.swift`
    - Added a static `orientationMask` used by `application(_:supportedInterfaceOrientationsFor:)` so UIKit reports the correct orientations at any given time.
    - Registered the `orientation_lock` channel through the `FlutterPluginRegistry` (avoids `rootViewController` access during `didFinishLaunchingWithOptions`).
    - `updateOrientationMask` now:
      - updates the mask and, on phones, forces device orientation to the expected direction to avoid mismatch states.
      - refreshes supported orientations (`setNeedsUpdateOfSupportedInterfaceOrientations` guarded for iOS 16+) and triggers `attemptRotationToDeviceOrientation()`.
  - `ios/Runner/SceneDelegate.swift` kept minimal (channel setup lives in AppDelegate via registrar).

## Why this approach
- The UIScene errors were caused by UIKit reporting a portrait-only controller while Flutter/BetterPlayer tried to rotate into landscape. By moving the authoritative orientation support into the iOS app delegate and keeping Flutter in sync, we eliminate the conflict rather than suppressing the warning.
- Using a centralized policy avoids scattered orientation changes, and ensures fullscreen transitions are the only times the phone’s orientation mask changes.
- The fullscreen route customization addresses UX friction where the default BetterPlayer fullscreen view hides the in-page back affordance.
- The downloads fullscreen back handler now aligns with user expectation by exiting both fullscreen and the player page in one action.

## Testing
- `flutter analyze`
  - no issues
- `flutter test`
  - all tests passed
- `flutter test test/src/features/downloads/presentation/download_task_controller_test.dart`
  - passed