### PR TITLE
Test downloaded-file lookup for cached resources

### DIFF
--- a/lib/src/features/courses/presentation/course_player_page.dart
+++ b/lib/src/features/courses/presentation/course_player_page.dart
@@ -58,6 +58,16 @@ String resourceDownloadKeyFor(LessonResource resource) {
   return '${resource.type.name}:${normalizeResourceUrl(resource.url)}';
 }
 
+@visibleForTesting
+DownloadedFile? downloadedFileForResource(
+  LessonResource resource,
+  Map<String, DownloadedFile> filesByKey,
+) {
+  final normalizedKey = resourceDownloadKeyFor(resource);
+  return filesByKey[normalizedKey] ??
+      filesByKey['${resource.type.name}:${resource.url}'];
+}
+
 Widget buildTopSnackBar(BuildContext context, String message) {
   final colorScheme = Theme.of(context).colorScheme;
   return SafeArea(
@@ -1227,9 +1237,7 @@ class _CoursePlayerPageState extends State<CoursePlayerPage>
   }
 
   DownloadedFile? _downloadedFileForResource(LessonResource resource) {
-    final normalizedKey = _resourceKey(resource);
-    return _downloadedResourceFiles[normalizedKey] ??
-        _downloadedResourceFiles['${resource.type.name}:${resource.url}'];
+    return downloadedFileForResource(resource, _downloadedResourceFiles);
   }
 
   Future<void> _refreshDownloadedResources() async {

--- a/test/src/features/courses/presentation/course_player_page_test.dart
+++ b/test/src/features/courses/presentation/course_player_page_test.dart
@@ -1,5 +1,6 @@
 import 'package:fcd_app/src/features/courses/data/models/lesson_resource.dart';
 import 'package:fcd_app/src/features/courses/presentation/course_player_page.dart';
+import 'package:fcd_app/src/features/downloads/data/models/downloaded_file.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -84,6 +85,72 @@ void main() {
         resourceDownloadKeyFor(resource),
         'video:https://example.com/video.mp4',
       );
+    });
+  });
+
+  group('downloadedFileForResource', () {
+    test('returns match when url has query params stored normalized', () {
+      const resource = LessonResource(
+        type: LessonResourceType.audio,
+        url: 'https://example.com/audio.mp3?token=abc',
+        name: 'Audio',
+        order: 1,
+      );
+      final file = DownloadedFile(
+        id: 'audio:https://example.com/audio.mp3',
+        url: 'https://example.com/audio.mp3?token=abc',
+        name: 'Audio',
+        type: 'audio',
+        localPath: '/tmp/audio.mp3',
+        downloadedAt: DateTime(2026, 1, 1),
+        localArtworkPath: '',
+      );
+      final filesByKey = <String, DownloadedFile>{
+        'audio:https://example.com/audio.mp3': file,
+      };
+
+      final match = downloadedFileForResource(resource, filesByKey);
+
+      expect(match, file);
+    });
+
+    test('falls back to raw url key when normalized key is missing', () {
+      const resource = LessonResource(
+        type: LessonResourceType.video,
+        url: 'https://example.com/video.mp4',
+        name: 'Video',
+        order: 1,
+      );
+      final file = DownloadedFile(
+        id: 'video:https://example.com/video.mp4',
+        url: resource.url,
+        name: 'Video',
+        type: 'video',
+        localPath: '/tmp/video.mp4',
+        downloadedAt: DateTime(2026, 1, 1),
+        localArtworkPath: '',
+      );
+      final filesByKey = <String, DownloadedFile>{
+        'video:${resource.url}': file,
+      };
+
+      final match = downloadedFileForResource(resource, filesByKey);
+
+      expect(match, file);
+    });
+
+    test('returns null when there is no match', () {
+      const resource = LessonResource(
+        type: LessonResourceType.document,
+        url: 'https://example.com/guide.pdf',
+        name: 'Guide',
+        order: 1,
+      );
+      final filesByKey = <String, DownloadedFile>{};
+
+      final match = downloadedFileForResource(resource, filesByKey);
+
+      expect(match, isNull);
     });
   });
   testWidgets('buildTopSnackBar aligns to the top of the screen', (tester) async {


### PR DESCRIPTION
## Summary
- cover the downloaded-file lookup behavior used when a course resource already has a local download
- validate normalized-url keys and legacy raw-url fallback behavior for cached downloads
- add null-case coverage to document missing downloads cleanly

## Testing
- not run (tests not requested)