### PR TITLE
Fix iPad UI jump after fullscreen

### DIFF
--- a/lib/src/features/downloads/presentation/downloaded_video_page.dart
+++ b/lib/src/features/downloads/presentation/downloaded_video_page.dart
@@ -24,11 +24,6 @@ class _DownloadedVideoPageState extends State<DownloadedVideoPage> {
   bool _didApplySystemUiMode = false;
 
   @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     final mediaQuery = MediaQuery.maybeOf(context);

--- a/lib/src/features/downloads/presentation/downloaded_video_page.dart
+++ b/lib/src/features/downloads/presentation/downloaded_video_page.dart
@@ -29,6 +29,8 @@ class _DownloadedVideoPageState extends State<DownloadedVideoPage> {
     if (mediaQuery == null) {
       return;
     }
+    // Tablet classification can change on iPad when the app window is resized,
+    // so keep system UI mode aligned with the current layout each rebuild.
     _isTablet = OrientationPolicy.isTabletForSize(mediaQuery.size);
     _applySystemUiModeForCurrentLayout();
     if (_controller == null && !_isPreparingController) {

--- a/lib/src/features/downloads/presentation/downloaded_video_page.dart
+++ b/lib/src/features/downloads/presentation/downloaded_video_page.dart
@@ -21,7 +21,6 @@ class _DownloadedVideoPageState extends State<DownloadedVideoPage> {
   String? _error;
   bool _isTablet = false;
   bool _isPreparingController = false;
-  bool _didApplySystemUiMode = false;
 
   @override
   void didChangeDependencies() {
@@ -31,7 +30,7 @@ class _DownloadedVideoPageState extends State<DownloadedVideoPage> {
       return;
     }
     _isTablet = OrientationPolicy.isTabletForSize(mediaQuery.size);
-    _applySystemUiModeIfNeeded();
+    _applySystemUiModeForCurrentLayout();
     if (_controller == null && !_isPreparingController) {
       _prepareController();
     }
@@ -51,16 +50,15 @@ class _DownloadedVideoPageState extends State<DownloadedVideoPage> {
     super.dispose();
   }
 
-  void _applySystemUiModeIfNeeded() {
-    if (_didApplySystemUiMode) {
-      return;
-    }
-    _didApplySystemUiMode = true;
+  void _applySystemUiModeForCurrentLayout() {
     // iPad should stay edge-to-edge; immersive mode shifts safe-area insets
     // when the fullscreen route opens/closes and causes a visible jump.
-    if (!_isTablet) {
-      SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
-    }
+    //
+    // Re-apply when MediaQuery changes so resizable tablet windows that cross
+    // the tablet breakpoint keep the same intended phone/tablet behavior.
+    SystemChrome.setEnabledSystemUIMode(
+      _isTablet ? SystemUiMode.edgeToEdge : SystemUiMode.immersiveSticky,
+    );
   }
 
   Future<void> _prepareController() async {

--- a/lib/src/features/downloads/presentation/downloaded_video_page.dart
+++ b/lib/src/features/downloads/presentation/downloaded_video_page.dart
@@ -61,6 +61,8 @@ class _DownloadedVideoPageState extends State<DownloadedVideoPage> {
       return;
     }
     _didApplySystemUiMode = true;
+    // iPad should stay edge-to-edge; immersive mode shifts safe-area insets
+    // when the fullscreen route opens/closes and causes a visible jump.
     if (!_isTablet) {
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
     }
@@ -104,6 +106,8 @@ class _DownloadedVideoPageState extends State<DownloadedVideoPage> {
         allowedScreenSleep: false,
         handleLifecycle: false,
         autoDispose: false,
+        // Keep downloaded videos opening fullscreen on phones, but not on iPad
+        // where entering fullscreen should not toggle immersive system UI.
         fullScreenByDefault: !_isTablet,
         eventListener: _handleVideoEvents,
         routePageBuilder: _buildFullscreenRoute,
@@ -140,6 +144,8 @@ class _DownloadedVideoPageState extends State<DownloadedVideoPage> {
   }
 
   void _handleVideoEvents(BetterPlayerEvent event) {
+    // Ignore fullscreen orientation/system-UI transitions on iPad to keep
+    // layout insets stable while BetterPlayer opens and closes fullscreen.
     if (_isTablet) {
       return;
     }

--- a/lib/src/features/downloads/presentation/downloaded_video_page.dart
+++ b/lib/src/features/downloads/presentation/downloaded_video_page.dart
@@ -21,11 +21,11 @@ class _DownloadedVideoPageState extends State<DownloadedVideoPage> {
   String? _error;
   bool _isTablet = false;
   bool _isPreparingController = false;
+  bool _didApplySystemUiMode = false;
 
   @override
   void initState() {
     super.initState();
-    SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
   }
 
   @override
@@ -36,6 +36,7 @@ class _DownloadedVideoPageState extends State<DownloadedVideoPage> {
       return;
     }
     _isTablet = OrientationPolicy.isTabletForSize(mediaQuery.size);
+    _applySystemUiModeIfNeeded();
     if (_controller == null && !_isPreparingController) {
       _prepareController();
     }
@@ -48,9 +49,21 @@ class _DownloadedVideoPageState extends State<DownloadedVideoPage> {
       isTablet: _isTablet,
       ignoreFullscreenFlag: true,
     );
-    SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+    if (!_isTablet) {
+      SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+    }
     _controller?.dispose(forceDispose: true);
     super.dispose();
+  }
+
+  void _applySystemUiModeIfNeeded() {
+    if (_didApplySystemUiMode) {
+      return;
+    }
+    _didApplySystemUiMode = true;
+    if (!_isTablet) {
+      SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
+    }
   }
 
   Future<void> _prepareController() async {


### PR DESCRIPTION
Pull request overview
This PR adjusts downloaded video playback system UI handling to avoid iPad safe-area shifts after fullscreen while preserving immersive behavior on phones.

Changes:

Defers system UI mode selection until after tablet detection.
Skips immersive system UI mode for tablet-sized layouts.
Tracks whether system UI mode has already been applied.